### PR TITLE
replaced scoped blocks

### DIFF
--- a/cmd/virsnap/clean.go
+++ b/cmd/virsnap/clean.go
@@ -90,7 +90,6 @@ func cleanRun(cmd *cobra.Command, args []string) {
 	// the exit code of the program after iterating over the virtual machines.
 	failed := false
 
-vmfor:
 	for _, vm := range vms {
 
 		// iterate over the domains and clean the snapshots for each of it
@@ -105,12 +104,12 @@ vmfor:
 			continue
 		}
 
-		// scoped block for efficiently freeing the snapshots
-		{
+		// anonymous function for safely calling defer
+		func() {
 			defer virt.FreeSnapshots(logger, snapshots)
 
 			if len(snapshots) <= keepVersions {
-				continue vmfor // continue with next VM
+				return // anonymous function for safely calling defer
 			}
 
 			// iterate over the snapshot exceeding the k snapshots that should
@@ -142,7 +141,7 @@ vmfor:
 							err,
 						)
 						failed = true
-						continue vmfor // continue with next VM
+						return
 					}
 				} else {
 					logger.Infof("skipping removal of snapshot '%s' of VM '%s'",
@@ -151,7 +150,7 @@ vmfor:
 					)
 				}
 			}
-		}
+		}()
 
 	}
 	// TODO (obitech): improve error handling

--- a/cmd/virsnap/create.go
+++ b/cmd/virsnap/create.go
@@ -137,8 +137,8 @@ func createRun(cmd *cobra.Command, args []string) {
 			// no continue here, since we want to startup the VM is any case!
 		}
 
-		// scoped block for efficiently freeing the snapshots
-		{
+		// anonymous function for safely calling defer
+		func() {
 			defer snapshot.Free()
 
 			if shutdown {
@@ -160,12 +160,12 @@ func createRun(cmd *cobra.Command, args []string) {
 							vm.Descriptor.Name,
 							err,
 						)
-						continue // continue with next VM
+						return // anonymous function for safely calling defer
 					}
 
 					logger.Warnf("state of VM '%s' is now '%s'", vm.Descriptor.Name,
 						newState)
-					continue // continue with next VM
+					return // anonymous function for safely calling defer
 				}
 			}
 
@@ -173,7 +173,7 @@ func createRun(cmd *cobra.Command, args []string) {
 				snapshot.Descriptor.Name,
 				vm.Descriptor.Name,
 			)
-		}
+		}()
 
 	}
 

--- a/cmd/virsnap/export.go
+++ b/cmd/virsnap/export.go
@@ -105,8 +105,8 @@ func exportRun(cmd *cobra.Command, args []string) {
 		}
 		logger.Debugf("finshed shutdown process of VM '%s'", vm.Descriptor.Name)
 
-		// scoped block for efficiently restoring the previous state of the VM
-		{
+		// anonymous function for safely calling defer
+		func() {
 			// restore previous state of VM
 			defer func() {
 				logger.Debugf("restoring previous state of vm '%s'", vm.Descriptor.Name)
@@ -156,7 +156,7 @@ func exportRun(cmd *cobra.Command, args []string) {
 			}
 			logger.Infof("Exported VM '%s'", vm.Descriptor.Name)
 
-		}
+		}()
 	}
 
 	// TODO (obitech): improve error handling

--- a/init/systemd/virsnap.service
+++ b/init/systemd/virsnap.service
@@ -19,4 +19,4 @@ ExecStart=/usr/local/bin/virsnap clean --keep 30 --assume-yes --log-level debug 
 ExecStart=/usr/local/bin/virsnap export --output-dir "/ADD_YOUR_PATH" --log-level debug --snapshot=true "^.*$"
 
 # Create a new snapshot of any VM when the VM is shutoff.
-# ExecStart=/usr/local/bin/virsnap create --shutdown --force --verbose "^.*$"
+# ExecStart=/usr/local/bin/virsnap create --shutdown --force --log-level debug "^.*$"


### PR DESCRIPTION
The scoped blocks were replaced by anonymous functions, since defer calls are only triggered when leaving a function frame and not a scope.